### PR TITLE
Add call method to execute a function

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -74,8 +74,16 @@ class Action
             "$filename.php"
         ]);
 
+        $this->action->log("[TAO] Source file path resolved: $path");
+
         if (!is_readable($path)) {
-            throw new \Exception('Source file not readable');
+            $this->action->error(
+                'Source file not readable',
+                1,
+                '500 Internal Server Error'
+            );
+
+            return '';
         }
 
         return $path;
@@ -127,21 +135,19 @@ class Action
      */
     public function call(callable $callback = null)
     {
+        $this->action->log(
+            "[TAO] Call requested from action: {$this->action->getActionName()}"
+        );
         if (!$callback) {
-            try {
-                $callback = require $this->getSourcePath(
-                    $this->action->getActionName()
-                );
-            } catch (\Throwable $e) {
-                $this->action->error(
-                    "[TAO] Error reading source file for {$this->action->getActionName()}"
-                );
-
+            $path = $this->getSourcePath($this->action->getActionName());
+            if ($path) {
+                $callback = require $path;
+            } else {
                 return $this;
             }
         }
 
-        $this->action->log("[TAO] Call action: {$this->action->getActionName()}");
+        $this->action->log("[TAO] Called action: {$this->action->getActionName()}");
         $callback($this);
 
         return $this;


### PR DESCRIPTION
This PR adds a `call()` method to execute a function that will receive an instance of `Tao\Action` as argument.

The function can optionally be provided to the method. Otherwise, a source file will be searched in the actions folder, expecting it to return a function.

To get the source file a `getSourcePath()` private method was created that could potentially be used in the `load()` method to unify the logic.

Examples of use:
```php
Tao\Service::init([
    'first' => function (Action $action) {
        // will search a source file in "actions/first.php"
        return Tao\Action::init($action)->call()->run();
    },

    'second' => function (Action $action) {
        // will search a source file in "other_actions/source.php"
        return Tao\Action::init($action)->call(require __DIR__ . '/other_actions/source.php')->run();
    }

    'third' => function (Action $action) {
        // will execute the given function
        return Tao\Action::init($action)->call(function (Tao\Action $action) {
            // Action logic
        })->run();
    }
])->run();
```